### PR TITLE
Updated for Datadog Agent v6/v7

### DIFF
--- a/openvpn.py
+++ b/openvpn.py
@@ -1,28 +1,31 @@
-import ast
-from checks import AgentCheck
-from subprocess import check_output
+try:
+    from datadog_checks.base import AgentCheck
+except ImportError:
+    from checks import AgentCheck
+from datadog_checks.utils.subprocess_output import get_subprocess_output
 
 
 class OpenVPN(AgentCheck):
-
-
     def check(self, instance):
-        metric_prefix = self.init_config.get('metric_prefix', 'openvpn')
+        metric_prefix = self.init_config.get("metric_prefix", "openvpn")
         license_usage = self.get_license_usage()
-        self.gauge('%s.licenses_used' % metric_prefix, license_usage['used'])
-        self.gauge('%s.licenses_available' % metric_prefix, license_usage['available'])
-        self.gauge('%s.licenses_total' % metric_prefix, license_usage['total'])
-
+        self.gauge("%s.licenses_used" % metric_prefix, license_usage["used"])
+        self.gauge("%s.licenses_available" % metric_prefix, license_usage["available"])
+        self.gauge("%s.licenses_total" % metric_prefix, license_usage["total"])
 
     def get_license_usage(self):
-        sacli_path = self.init_config.get('sacli_path', '/usr/local/openvpn_as/scripts/sacli')
-        lic_usage = ast.literal_eval(check_output(["sudo", sacli_path, "LicUsage"]).decode('utf-8'))
+        sacli_path = self.init_config.get(
+            "sacli_path", "/usr/local/openvpn_as/scripts/sacli"
+        )
+        sacli_licusage = ["sudo", sacli_path, "LicUsage"]
+
+        out, err, retcode = get_subprocess_output(
+            sacli_licusage, self.log, raise_on_empty_output=True
+        )
+        out_split = out[3:-2].splitlines()
+        lic_usage = [int(n.strip(", ")) for n in out_split]
         return {
-                    'used': lic_usage[0],
-                    'total': lic_usage[1],
-                    'available': lic_usage[1] - lic_usage[0]
-                }
-
-
-if __name__ == '__main__':
-    check.check(instance)
+            "used": lic_usage[0],
+            "total": lic_usage[1],
+            "available": lic_usage[1] - lic_usage[0],
+        }


### PR DESCRIPTION
This could be a bit rough around the edges but it does work. You're welcome to change pieces of this, but I wanted to push my changes up to you for review. This adjusts your Python to accommodate changes in DataDog v6/v7. They removed support for calling the subprocess module.
> Since the Python interpreter that runs the checks is embedded in the multi-threaded Go runtime, using the subprocess or multithreading modules from the Python standard library is not supported in Agent version 6 and later.
They implemeted their own module [get_subprocess_output](https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks.utils.html#module-datadog_checks.base.utils.subprocess_output).
My code editor did a bit of formatting per my normal, but you're welcome to adjust whatever you'd like.